### PR TITLE
feat: Add Middleware

### DIFF
--- a/serverLogRequestsToFile/main.go
+++ b/serverLogRequestsToFile/main.go
@@ -1,12 +1,75 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
+
+type RequestLog struct {
+	Method        string
+	Uri           string
+	Host          string
+	Header        string
+	RemoteAddr    string
+	ContentLength string
+	Time          time.Time
+}
+
+func (l *RequestLog) createLogFromRequest(r *http.Request) *RequestLog {
+	logData := RequestLog{
+		Method:        r.Method,
+		Uri:           r.RequestURI,
+		Host:          r.Host,
+		Header:        fmt.Sprint(r.Header),
+		RemoteAddr:    r.RemoteAddr,
+		ContentLength: strconv.FormatInt(r.ContentLength, 10),
+		Time:          time.Now().UTC(),
+	}
+	return &logData
+}
+
+func writeLogToFile(logData *RequestLog) error {
+	id := uuid.New()
+	fileName := fmt.Sprintf("/tmp/%s", id.String())
+	f, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	out, err := json.Marshal(logData)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(string(out))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func loggingToFileMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var requestLog RequestLog
+		logData := requestLog.createLogFromRequest(r)
+		err := writeLogToFile(logData)
+		if err != nil {
+			log.Println(err)
+			fmt.Fprint(w, fmt.Sprint(http.StatusInternalServerError))
+		} else {
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+type MiddlewareFunc func(http.Handler) http.Handler
 
 func HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
@@ -16,5 +79,6 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/", HomeHandler)
+	r.Use(loggingToFileMiddleware)
 	log.Fatal(http.ListenAndServe(":8000", r))
 }


### PR DESCRIPTION
Add a Middleware that logs an HTTP Request.

- Define the RequestLog struct and define fields of the HTTP Request
that need to be logged (ex.Method,URI,Host,etc..). Also, define a
time field to store the time the HTTP Request was made.

- Implement createLogFromRequest (a RequestLog method) to read the
set the structs fields. Also, acquire the current time.

- Implement writeLogToFile to write the logData (of type RequestLog)
to a file in the tmp directory. Generate a unique uuid for the file
name, Marshal the struct into a json and then write it to the file.

- Implement loggingToFileMiddleware. Create the log from the Request
then call writeLogToFile(). In case of failure return
InternalServerError status code, else serve the next handler in the
chain.